### PR TITLE
fixed callback not called bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ function iTach(config) {
       debug && console.log("queue is not empty");
       return;
     }
-    if(done === undefined && typeof  now === ' function') {
+    if(done === undefined && typeof  now === 'function') {
       done = now;
     }
 


### PR DESCRIPTION
When calling the send method, the callback would not be called because of this typo, raising an error:

node-itach :: cannot find callback with id %s in callbacks hash.